### PR TITLE
remove erroneous minicard title whitespace

### DIFF
--- a/client/components/cards/minicard.styl
+++ b/client/components/cards/minicard.styl
@@ -77,6 +77,9 @@
       height: @width
       border-radius: 2px
       margin-left: 3px
+  .minicard-title
+    p:last-child
+      margin-bottom: 0
   .dates
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
introduced by the markdown viewer in commit 309c1d0 (the markdown viewer uses `<p>` tags which have a margin-bottom)